### PR TITLE
do_underscores option and UTF-8 code point entities

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -363,8 +363,11 @@ class Html2Text
     // replace known html entities
     $text = UTF8::html_entity_decode($text);
 
+    // replace html entities which represent UTF-8 codepoints.
+    $text = preg_replace_callback("/&#\d{2,4};/", array($this, 'entityCallback'), $text);
+
     // remove unknown/unhandled entities (this cannot be done in search-and-replace block)
-    $text = preg_replace('/&([a-zA-Z0-9]{2,6}|#\d{2,4});/', '', $text);
+    $text = preg_replace('/&[a-zA-Z0-9]{2,6};/', '', $text);
 
     // convert "|+|amp|+|" into "&", need to be done after handling of unknown entities
     // this properly handles situation of "&amp;quot;" in input string
@@ -566,6 +569,19 @@ class Html2Text
       default:
         return '';
     }
+  }
+
+  /**
+   * Callback function for preg_replace_callback use.
+   *
+   * @param  array $matches PREG matches
+   *
+   * @return string
+   */
+  protected function entityCallback(&$matches)
+  {
+    // Convert from HTML-ENTITIES to UTF-8
+    return mb_convert_encoding($matches[0], "UTF-8", "HTML-ENTITIES");
   }
 
   /**

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -581,7 +581,7 @@ class Html2Text
   protected function entityCallback(&$matches)
   {
     // Convert from HTML-ENTITIES to UTF-8
-    return mb_convert_encoding($matches[0], "UTF-8", "HTML-ENTITIES");
+    return mb_convert_encoding($matches[0], 'UTF-8', 'HTML-ENTITIES');
   }
 
   /**

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -61,10 +61,6 @@ class Html2Text
     '/(<p[^>]*>|<\/p>)/i'                            => "\n\n",
     // <br>
     '/<br[^>]*>/i'                                   => "\n",
-    // <i>
-    '/<i[^>]*>(.*?)<\/i>/i'                          => '_\\1_',
-    // <em>
-    '/<em[^>]*>(.*?)<\/em>/i'                        => '_\\1_',
     // <ul> and </ul>
     '/(<ul[^>]*>|<\/ul>)/i'                          => "\n\n",
     // <ol> and </ol>
@@ -121,6 +117,8 @@ class Html2Text
       '/<(strong)( [^>]*)?>(.*?)<\/strong>/i',                 // <strong>
       '/<(th)( [^>]*)?>(.*?)<\/th>/i',                         // <th> and </th>
       '/<(a) [^>]*href=("|\')([^"\']+)\2([^>]*)>(.*?)<\/a>/i', // <a href="">
+      '/<(i)( [^>]*)?>(.*?)<\/i>/i',                           // <i>
+      '/<(em)( [^>]*)?>(.*?)<\/em>/i',                         // <em>
   );
 
   /**
@@ -177,6 +175,11 @@ class Html2Text
     //
     // Convert strong and bold to uppercase?
     'do_upper' => true,
+    //
+    // "do_underscores" ------------>
+    //
+    // Surround emphasis and italics with underscores?
+    'do_underscores' => true,
     //
     // "do_links ------------>
     //
@@ -541,6 +544,13 @@ class Html2Text
         return $this->toupper($matches[3] . "\n");
       case 'h':
         return $this->toupper("\n\n" . $matches[3] . "\n\n");
+      case 'i':
+      case 'em':
+        $subject = $matches[3];
+        if ($this->options['do_underscores'] === true) {
+          $subject = '_' . $subject . '_';
+        }
+        return $subject;
       case 'a':
 
         // override the link method

--- a/tests/UnderscoresTest.php
+++ b/tests/UnderscoresTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace voku\Html2Text\tests;
+
+use \voku\Html2Text\Html2Text;
+
+/**
+ * Class UnderscoresTest
+ *
+ * @package Html2Text
+ */
+class UnderscoresTest extends \PHPUnit_Framework_TestCase
+{
+  public function testUnderscores()
+  {
+    $html = <<<'EOT'
+<html>
+  <body>
+    <p>An <i>extremely</i> important <em>emphasis</em>.</p>
+  </body>
+</html>
+EOT;
+
+    $expected = <<<'EOT'
+An _extremely_ important _emphasis_.
+EOT;
+
+    $html2text = new Html2Text($html);
+    $this->assertEquals($expected, $html2text->getText());
+  }
+
+  public function testNoUnderscores()
+  {
+    $html = <<<'EOT'
+<html>
+  <body>
+    <p>An <i>extremely</i> important <em>emphasis</em>.</p>
+  </body>
+</html>
+EOT;
+
+    $expected = <<<'EOT'
+An extremely important emphasis.
+EOT;
+
+    $html2text = new Html2Text($html, array('do_underscores' => false));
+    $this->assertEquals($expected, $html2text->getText());
+  }
+}

--- a/tests/test8Html.html
+++ b/tests/test8Html.html
@@ -1,2 +1,2 @@
 <p style="font-family:Tahoma, sans-serif; font-size:13px;"><span style="color:#999999;">Цитат</span></p>
-<blockquote type="cite" style="border:none; padding:0; margin:0; background-color:#1010ff;"><div style="margin-left:2px; background-color:white;">Quoted text</div></blockquote>
+<blockquote type="cite" style="border:none; padding:0; margin:0; background-color:#1010ff;"><div style="margin-left:2px; background-color:white;">Here&#39;s some quoted text.</div></blockquote>

--- a/tests/test8Html.txt
+++ b/tests/test8Html.txt
@@ -1,3 +1,3 @@
 Цитат
 
-> Quoted text
+> Here's some quoted text.


### PR DESCRIPTION
Added the option not to insert underscores when `<i>` and `<em>` are used.
Added conversion of HTML entities such as &#39; which represent UTF-8 code points. (These were previously stripped out.)

Regarding the change to entity decoding behavior:
I felt that the added behavior was in line with the intent of the existing code, which appeared to try to convert as much as possible, so I didn't make it optional. This does mean, however that it is a backwards-incompatible change.
If you agree with the inclusion of this behavior by default, please make the appropriate version number change for a backwards-incompatible change.
If you would prefer to make this an option, and default to the old stripping behavior, let me know.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/voku/html2text/4)

<!-- Reviewable:end -->
