### PR TITLE
Converting all preg offsets at the beginning

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -85,6 +85,9 @@ class Html2Text
     '/(<tr[^>]*>|<\/tr>)/i'                          => "\n",
     // <td> and </td>
     '/<td[^>]*>(.*?)<\/td>/i'                        => "\\1\n",
+    // img alt text
+    '/<img(?:.*?)alt=("|\')(.*?)("|\')(?:.*?)>/i'    => 'image: \\1\\2\\3',
+    '/image: ""/'                                    => '',
     // <span class="_html2text_ignore">...</span>
     '/<span class="_html2text_ignore">.+?<\/span>/i' => '',
   );
@@ -103,6 +106,8 @@ class Html2Text
     '/&(amp|#38);/i' => '|+|amp|+|',
     // runs of spaces, post-handling
     '/[ ]{2,}/'      => ' ',
+    // prevent strange characters
+    '/&nbsp;/i'      => ' ',
   );
 
   /**
@@ -404,7 +409,6 @@ class Html2Text
       foreach ($matches[0] as $index => $m) {
         $matches[0][$index][1] = UTF8::strlen(substr($text, 0, $m[1]));
       }
-
 
       foreach ($matches[0] as $m) {
         if ($m[0][0] == '<' && $m[0][1] == '/') {

--- a/tests/BlockquoteTest.php
+++ b/tests/BlockquoteTest.php
@@ -135,4 +135,33 @@ EOT;
     $html2text = new Html2Text($html);
     $this->assertEquals($expected, $html2text->getText());
   }
+
+  public function testBlockquoteWithAttribute()
+  {
+    $html = <<<'EOT'
+<html>
+<body>
+  <blockquote type="cite">
+    <div>
+      <span>some quoted words</span>
+    </div>
+  </blockquote>
+  <blockquote type="cite">
+    <div>
+      <span>second quote</span>
+    </div>
+  </blockquote>
+</body>
+</html>
+EOT;
+
+    $expected = <<<'EOT'
+> some quoted words
+
+> second quote
+EOT;
+
+    $html2text = new Html2Text($html);
+    $this->assertEquals($expected, $html2text->getText());
+  }
 }


### PR DESCRIPTION
Converting the preg offsets as they came up turned out not to work so well with multiple blockquotes. Since $text gets modified as we go along, and $text is used to convert the preg offsets, the calculations involving start/end/diff got more and more off as the loop progressed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/voku/html2text/6)

<!-- Reviewable:end -->
