### PR TITLE
Fix expression is not allowed as field default value

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -215,9 +215,9 @@ class Html2Text
     // replace the image-placeholder-description
     '/\[\[_html2text_image\]\]/' => 'Image: ',
     // replace the link-list-placeholder-description
-    '/\[\[_html2text_links\]\]/' => "\n\n" . 'Links:' . "\n------\n",
+    '/\[\[_html2text_links\]\]/' => "\n\nLinks:\n------\n",
   );
-  
+
   /**
    * Replace the default "\n\n" . 'Links:' . "\n------\n"-prefix for link-lists.
    *


### PR DESCRIPTION
Remove concatenation in string, because of syntax error in PHP <= 5.5

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/html2text/11)

<!-- Reviewable:end -->
